### PR TITLE
hotfix-#50 : random diary 조회시 null일 경우 npe 버그 수정

### DIFF
--- a/src/main/java/com/example/picturediary/domain/diary/dto/DiaryWithStampListDto.java
+++ b/src/main/java/com/example/picturediary/domain/diary/dto/DiaryWithStampListDto.java
@@ -5,13 +5,16 @@ import com.example.picturediary.domain.diary.entity.Diary;
 import com.example.picturediary.domain.stamp.entity.Stamp;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.util.ObjectUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
 @Setter
+@NoArgsConstructor
 public class DiaryWithStampListDto
 {
     private Long diaryId;
@@ -40,6 +43,11 @@ public class DiaryWithStampListDto
 
     public static DiaryWithStampListDto of(Diary diary)
     {
+        if (ObjectUtils.isEmpty(diary))
+        {
+            return DiaryWithStampListDto.builder().build();
+        }
+
         return DiaryWithStampListDto.builder()
             .diaryId(diary.getDiaryId())
             .imageUrl(diary.getImageUrl())
@@ -48,5 +56,17 @@ public class DiaryWithStampListDto
             .stampList(diary.getStampList())
             .content(diary.getContent())
             .build();
+    }
+
+    public static boolean isNull(DiaryWithStampListDto diary)
+    {
+        // 모든 필드가 null 인지 확인
+        return (diary.getDiaryId() == null)
+            && (diary.getImageUrl() == null)
+            && (diary.getWeather() == null)
+            && (diary.getCreatedDate() == null)
+            && (diary.getStampList() == null)
+            && (diary.getContent() == null)
+            ;
     }
 }

--- a/src/main/java/com/example/picturediary/domain/diary/response/RandomSingleDiaryWithStampResponse.java
+++ b/src/main/java/com/example/picturediary/domain/diary/response/RandomSingleDiaryWithStampResponse.java
@@ -8,7 +8,9 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.util.CollectionUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,6 +18,7 @@ import java.util.stream.Collectors;
 
 @Getter
 @Setter
+@NoArgsConstructor
 @ApiModel(value = "랜덤 일기 단건 응답")
 public class RandomSingleDiaryWithStampResponse
 {
@@ -38,7 +41,7 @@ public class RandomSingleDiaryWithStampResponse
     private String content;
 
     @ApiModelProperty(value = "사용자가 자신이 해당 일기에 도장을 찍었는지 여부, 찍었으면 - true / 안 찍었으면 - false")
-    private boolean isStamped;
+    private Boolean isStamped;
 
     @Builder
     private RandomSingleDiaryWithStampResponse(
@@ -48,7 +51,7 @@ public class RandomSingleDiaryWithStampResponse
         LocalDateTime createdDate,
         List<StampInDiaryResponse> stampList,
         String content,
-        boolean isStamped)
+        Boolean isStamped)
     {
         this.diaryId = diaryId;
         this.imageUrl = imageUrl;

--- a/src/main/java/com/example/picturediary/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/example/picturediary/domain/diary/service/DiaryService.java
@@ -93,6 +93,11 @@ public class DiaryService
     {
         DiaryWithStampListDto randomDiary = diaryRepository.getRandomDiary(Long.parseLong(user.getUsername()));
 
+        if (DiaryWithStampListDto.isNull(randomDiary))
+        {
+            return RandomSingleDiaryWithStampResponse.builder().build();
+        }
+
         return RandomSingleDiaryWithStampResponse.of(randomDiary, Long.parseLong(user.getUsername()));
     }
 


### PR DESCRIPTION
random diary 조회시 null일 경우 아래와 같이 리턴

```json
{
    "diaryId": null,
    "imageUrl": null,
    "weather": null,
    "createdDate": null,
    "stampList": null,
    "content": null,
    "isStamped": null
}
```